### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   linux-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/TownSuite/TownSuite.MultiTenant/security/code-scanning/8](https://github.com/TownSuite/TownSuite.MultiTenant/security/code-scanning/8)

To fix this, explicitly declare minimal `GITHUB_TOKEN` permissions for the workflow. Since none of the jobs modify repository contents, create releases, or perform other write operations via the GitHub API, they only need read access to repository contents. The most straightforward fix without changing behavior is to add a `permissions:` block at the workflow root (top level), which will automatically apply to all jobs that do not specify their own permissions.

Concretely, in `.github/workflows/dotnet.yml`, insert a root-level `permissions:` section after the `on:` block and before `jobs:`. Set `contents: read` to match a minimal, read-only token and satisfy the CodeQL recommendation. No additional methods, imports, or other definitions are required, as this is purely a YAML configuration change. There is no need to add per-job `permissions` blocks unless different jobs require different scopes, which they do not here.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
