### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -6,6 +6,9 @@ on:
       - completed
 jobs:
   report:
+    permissions:
+      contents: read
+      checks: write
     runs-on: ubuntu-latest
     steps:
     - uses: dorny/test-reporter@v1


### PR DESCRIPTION
Potential fix for [https://github.com/TownSuite/TownSuite.MultiTenant/security/code-scanning/6](https://github.com/TownSuite/TownSuite.MultiTenant/security/code-scanning/6)

In general, this issue is fixed by explicitly adding a `permissions` block to the workflow (at the root or per job) that grants only the minimum permissions required. For read-only operations, this typically means `contents: read`; for actions that create or update checks, comments, or PRs, you selectively add `checks: write`, `pull-requests: write`, etc., instead of full write access to everything.

For this particular workflow, the `report` job uses `dorny/test-reporter@v1` to publish test results as a GitHub Check. That action typically needs to read the repository contents minimally and write to the Checks API. It does not need to push commits or manage packages. A minimal and safe permission set is therefore: `contents: read` (baseline read access) and `checks: write` (to create/update the test report check). To apply this without changing existing behavior, we add a `permissions` block at the job level under `jobs.report`, right before `runs-on: ubuntu-latest`. No imports or additional methods are required; this is a pure YAML configuration change within `.github/workflows/test-report.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
